### PR TITLE
[BUG] Fix parameter encoding in url.

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -53,7 +53,7 @@ func (g *Gitlab) ResourceUrl(url string, params map[string]string) string {
 
 	if params != nil {
 		for key, val := range params {
-			url = strings.Replace(url, key, val, -1)
+			url = strings.Replace(url, key, encodeParameter(val), -1)
 		}
 	}
 
@@ -97,7 +97,7 @@ func (g *Gitlab) ResourceUrlRaw(u string, params map[string]string) (string, str
 
 	if params != nil {
 		for key, val := range params {
-			u = strings.Replace(u, key, val, -1)
+			u = strings.Replace(u, key, encodeParameter(val), -1)
 		}
 	}
 
@@ -107,7 +107,7 @@ func (g *Gitlab) ResourceUrlRaw(u string, params map[string]string) (string, str
 	if err != nil {
 		return u, ""
 	}
-	opaque := "//" + p.Host + g.ApiPath + path
+	opaque := "//" + p.Host + p.Path
 	return u, opaque
 }
 

--- a/util.go
+++ b/util.go
@@ -1,0 +1,10 @@
+package gogitlab
+
+import (
+	"net/url"
+	"strings"
+)
+
+func encodeParameter(value string) string {
+	return strings.Replace(url.QueryEscape(value), "/", "%2F", 0)
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,11 @@
+package gogitlab
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParameterEncoding(t *testing.T) {
+	assert.Equal(t, encodeParameter("namespace/project"), "namespace\%2Fproject")
+	assert.Equal(t, encodeParameter("14"), "14")
+}


### PR DESCRIPTION
Fix encoding parameter for namespace usage in projects, and a fix for wrong url generation in case of reverse proxified gitlab.
