### PR TITLE
Configure SSL certificate check via API

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -34,7 +34,11 @@ var (
 )
 
 func NewGitlab(baseUrl, apiPath, token string) *Gitlab {
-	config := &tls.Config{InsecureSkipVerify: *skipCertVerify}
+	return NewGitlabCert(baseUrl, apiPath, token, *skipCertVerify)
+}
+
+func NewGitlabCert(baseUrl, apiPath, token string, skipVerify bool) *Gitlab {
+	config := &tls.Config{InsecureSkipVerify: skipVerify}
 	tr := &http.Transport{
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: config,


### PR DESCRIPTION
This change allows the certificate check to be disabled via the API.
