### PR TITLE
Fix example: crashed when Owner not set

### DIFF
--- a/examples/projects/main.go
+++ b/examples/projects/main.go
@@ -96,7 +96,9 @@ func main() {
 		fmt.Printf(format, "name", project.Name)
 		fmt.Printf(format, "description", project.Description)
 		fmt.Printf(format, "default branch", project.DefaultBranch)
-		fmt.Printf(format, "owner.name", project.Owner.Username)
+		if project.Owner != nil {
+			fmt.Printf(format, "owner.name", project.Owner.Username)
+		}
 		fmt.Printf(format, "public", strconv.FormatBool(project.Public))
 		fmt.Printf(format, "path", project.Path)
 		fmt.Printf(format, "path with namespace", project.PathWithNamespace)


### PR DESCRIPTION
When Owner field is not set (nil), the example crash.

I haven't investigate when Owner can be nil, but I added a test such that example does not crash.