### PR TITLE
Merge request notes

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -2,19 +2,21 @@ package gogitlab
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 )
 
 const (
-	projects_url               = "/projects"                         // Get a list of projects owned by the authenticated user
-	projects_search_url        = "/projects/search/:query"           // Search for projects by name
-	project_url                = "/projects/:id"                     // Get a specific project, identified by project ID or NAME
-	project_url_events         = "/projects/:id/events"              // Get project events
-	project_url_branches       = "/projects/:id/repository/branches" // Lists all branches of a project
-	project_url_members        = "/projects/:id/members"             // List project team members
-	project_url_member         = "/projects/:id/members/:user_id"    // Get project team member
-	project_url_merge_requests = "/projects/:id/merge_requests"      // List all merge requests of a project
+	projects_url               = "/projects"                                            // Get a list of projects owned by the authenticated user
+	projects_search_url        = "/projects/search/:query"                              // Search for projects by name
+	project_url                = "/projects/:id"                                        // Get a specific project, identified by project ID or NAME
+	project_url_events         = "/projects/:id/events"                                 // Get project events
+	project_url_branches       = "/projects/:id/repository/branches"                    // Lists all branches of a project
+	project_url_members        = "/projects/:id/members"                                // List project team members
+	project_url_member         = "/projects/:id/members/:user_id"                       // Get project team member
+	project_url_merge_requests = "/projects/:id/merge_requests"                         // List all merge requests of a project
+	merge_request_url_notes    = "/projects/:id/merge_requests/:merge_request_id/notes" // Manage comments for a given merge request
 )
 
 type Member struct {
@@ -87,6 +89,14 @@ type MergeRequest struct {
 	Author       *Member `json:"author,omitempty"`
 	Assignee     *Member `json:"assignee,omitempty"`
 	Description  string  `json:"description,omitempty"`
+}
+
+type MergeRequestNote struct {
+	Attachment interface{} `json:"attachment"`
+	Body       string      `json:"body"`
+	CreatedAt  string      `json:"created_at"`
+	Id         int         `json:"id"`
+	Author     *Member     `json:"author"`
 }
 
 /*
@@ -202,6 +212,43 @@ func (g *Gitlab) ProjectMergeRequests(id string, page int, per_page int, state s
 	var mr []*MergeRequest
 
 	contents, err := g.buildAndExecRequest("GET", url, nil)
+	if err == nil {
+		err = json.Unmarshal(contents, &mr)
+	}
+
+	return mr, err
+}
+
+/*
+Lists all comments on merge request.
+*/
+func (g *Gitlab) MergeRequestNotes(id string, merge_request_id string, page int, per_page int) ([]*MergeRequestNote, error) {
+	par := map[string]string{":id": id, ":merge_request_id": merge_request_id}
+	qry := map[string]string{
+		"page":     strconv.Itoa(page),
+		"per_page": strconv.Itoa(per_page)}
+	url := g.ResourceUrlQuery(merge_request_url_notes, par, qry)
+
+	var mr []*MergeRequestNote
+
+	contents, err := g.buildAndExecRequest("GET", url, nil)
+	if err == nil {
+		err = json.Unmarshal(contents, &mr)
+	}
+
+	return mr, err
+}
+
+/*
+Creates a new comment on a merge request.
+*/
+func (g *Gitlab) SendMergeRequestComment(id string, merge_request_id string, comment string) (*MergeRequestNote, error) {
+	par := map[string]string{":id": id, ":merge_request_id": merge_request_id}
+	url := g.ResourceUrlQuery(merge_request_url_notes, par, map[string]string{})
+
+	var mr *MergeRequestNote
+
+	contents, err := g.buildAndExecRequest("POST", url, []byte(fmt.Sprintf("body=%s", comment)))
 	if err == nil {
 		err = json.Unmarshal(contents, &mr)
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -57,6 +57,21 @@ func TestProjectMergeRequests(t *testing.T) {
 	}
 }
 
+func TestMergeRequestNotes(t *testing.T) {
+	ts, gitlab := Stub("stubs/projects/merge_requests/notes/index.json")
+	defer ts.Close()
+	notes, err := gitlab.MergeRequestNotes("1", "1", 0, 30)
+
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(notes), 1)
+
+	if len(notes) > 0 {
+		assert.Equal(t, notes[0].Id, 301)
+		assert.Equal(t, notes[0].Body, "Comment for MR")
+		assert.Equal(t, notes[0].Author.Username, "pipin")
+	}
+}
+
 func TestSearchProjectId(t *testing.T) {
 	ts, gitlab := Stub("stubs/projects/index.json")
 

--- a/stubs/projects/merge_requests/notes/index.json
+++ b/stubs/projects/merge_requests/notes/index.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 301,
+    "body": "Comment for MR",
+    "attachment": null,
+    "author": {
+      "id": 1,
+      "username": "pipin",
+      "email": "admin@example.com",
+      "name": "Pip",
+      "state": "active",
+      "created_at": "2013-09-30T13:46:01Z"
+    },
+    "created_at": "2013-10-02T08:57:14Z"
+  }
+]


### PR DESCRIPTION
extend the gitlab struct so it can read and write comments on merge request (over the 'note' resource)