### PR TITLE
add x-www-form-urlencoded header

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -77,6 +77,7 @@ func (g *Gitlab) buildAndExecRequest(method, url string, body []byte) ([]byte, e
 	if body != nil {
 		reader := bytes.NewReader(body)
 		req, err = http.NewRequest(method, url, reader)
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 	}


### PR DESCRIPTION
Gitlab needs to give a header when submitting HTTP body. 